### PR TITLE
Unify the group-by implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "groupby"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,24 @@ use regex::Regex;
 use std::collections::{BTreeSet, BTreeMap};
 use std::io::BufRead;
 
-fn groupby_unique(re: &Regex, group_id: Option<usize>) -> BTreeMap<String, BTreeSet<String>> {
-    let mut grouping: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+trait Group: Default + IntoIterator<Item = String> {
+    fn add(&mut self, line: String);
+}
+
+impl Group for BTreeSet<String> {
+    fn add(&mut self, line: String) {
+        self.insert(line);
+    }
+}
+
+impl Group for Vec<String> {
+    fn add(&mut self, line: String) {
+        self.push(line);
+    }
+}
+
+fn groupby<G: Group>(re: &Regex, group_id: Option<usize>) -> BTreeMap<String, G> {
+    let mut grouping: BTreeMap<String, G> = BTreeMap::new();
 
     let stdin = std::io::stdin();
     for line in stdin.lock().lines() {
@@ -19,50 +35,28 @@ fn groupby_unique(re: &Regex, group_id: Option<usize>) -> BTreeMap<String, BTree
             None => "***NO-MATCH***",
         };
 
-        grouping.entry(capture.to_string()).or_insert(BTreeSet::new()).insert(line.clone());
+        grouping.entry(capture.to_string()).or_insert_with(Default::default).add(line.clone());
     }
 
     return grouping;
+}
+
+fn print_groupby<G: Group>(re: &Regex, group_id: Option<usize>) {
+    for (group, members) in groupby::<G>(&re, group_id) {
+        println!("{}", group);
+        for line in members {
+            println!("    {}", line);
+        }
+    }
 }
 
 fn print_groupby_unique(re: &Regex, group_id: Option<usize>) {
-    for (group, members) in groupby_unique(&re, group_id) {
-        println!("{}", group);
-        for line in members {
-            println!("    {}", line);
-        }
-    }
-}
-
-
-fn groupby_all(re: &Regex, group_id: Option<usize>) -> BTreeMap<String, Vec<String>> {
-    let mut grouping: BTreeMap<String, Vec<String>> = BTreeMap::new();
-
-    let stdin = std::io::stdin();
-    for line in stdin.lock().lines() {
-        let line = line.unwrap();
-
-
-        let capture = match re.captures(&line) {
-            Some(captures) => captures.get(group_id.unwrap_or(0)).unwrap().as_str(),
-            None => "***NO-MATCH***",
-        };
-
-        grouping.entry(capture.to_string()).or_insert(Vec::new()).push(line.clone());
-    }
-
-    return grouping;
+    print_groupby::<BTreeSet<String>>(re, group_id);
 }
 
 fn print_groupby_all(re: &Regex, group_id: Option<usize>) {
-    for (group, members) in groupby_all(&re, group_id) {
-        println!("{}", group);
-        for line in members {
-            println!("    {}", line);
-        }
-    }
+    print_groupby::<Vec<String>>(re, group_id);
 }
-
 
 fn main() {
     let matches = App::new("groupby (lostutils)")


### PR DESCRIPTION
The only difference between them is what kind of data structure is used
as the inner type. This uses a private trait to unify both data
structures to the same interface and keeps just one copy of the code.

One of the suggestions for #1.

The change should be straight-forward, with one trick that may need a bit of explanation. The original code with `or_insert` create a new `BTreeSet` or `Vec` even when it wasn't needed and then simply threw it away when it found one is already present. This is because `or_insert` needs a value as the parameter and that one needs to be created before it is called. On the other hand, `or_insert_with` takes a function to create one only if it is needed.